### PR TITLE
Fix README.ko.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Kiko Now
 
-*Read this in other languages: [English](README.md), [한국어](README.ko.md).*
-
 **Jekyll** 은 GitHub Pages 로 호스팅하는 블로그를 만드는 최적의 정적 사이트 생성기입니다. ([Jekyll Repository](https://github.com/jekyll/jekyll))
 
 **Kiko Now** 는 **[Jekyll Now](https://github.com/barryclark/jekyll-now)** 를 기반으로 만들어진 Jekyll 블로그 테마로, 간단한 기본 설정만으로도 블로그를 쉽게 만들 수 있도록 하는 **Jekyll Now** 의 철학을 따르고 있습니다.


### PR DESCRIPTION
## Summary
- remove nonexistent Korean translation link in README

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: blocked from fetching gems)*

------
https://chatgpt.com/codex/tasks/task_b_6879dd1f11e883249495b70b167243d4