### PR TITLE
Fix http links in templates

### DIFF
--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -12,6 +12,6 @@
 	    })();
 
 	</script>
-	<noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+        <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 </div>
 {% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,7 @@
   {% include fonts.html %}
 
   <!--[if lt IE 9]>
-    <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <script src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/style.css" />

--- a/_includes/svg-icons.html
+++ b/_includes/svg-icons.html
@@ -46,7 +46,7 @@
   {% endif %}
 
   {% if site.footer-links.stackoverflow %}
-  <li><a href="http://stackoverflow.com/{{ site.footer-links.stackoverflow }}" class="icon-23 stackoverflow" title="StackOverflow"><svg viewBox="0 0 512 512"><path d="M294.8 361.2l-122 0.1 0-26 122-0.1L294.8 361.2zM377.2 213.7L356.4 93.5l-25.7 4.5 20.9 120.2L377.2 213.7zM297.8 301.8l-121.4-11.2 -2.4 25.9 121.4 11.2L297.8 301.8zM305.8 267.8l-117.8-31.7 -6.8 25.2 117.8 31.7L305.8 267.8zM321.2 238l-105-62 -13.2 22.4 105 62L321.2 238zM346.9 219.7l-68.7-100.8 -21.5 14.7 68.7 100.8L346.9 219.7zM315.5 275.5v106.5H155.6V275.5h-20.8v126.9h201.5V275.5H315.5z"/></svg><!--[if lt IE 9]><em>StackOverflow</em><![endif]--></a></li>
+  <li><a href="https://stackoverflow.com/{{ site.footer-links.stackoverflow }}" class="icon-23 stackoverflow" title="StackOverflow"><svg viewBox="0 0 512 512"><path d="M294.8 361.2l-122 0.1 0-26 122-0.1L294.8 361.2zM377.2 213.7L356.4 93.5l-25.7 4.5 20.9 120.2L377.2 213.7zM297.8 301.8l-121.4-11.2 -2.4 25.9 121.4 11.2L297.8 301.8zM305.8 267.8l-117.8-31.7 -6.8 25.2 117.8 31.7L305.8 267.8zM321.2 238l-105-62 -13.2 22.4 105 62L321.2 238zM346.9 219.7l-68.7-100.8 -21.5 14.7 68.7 100.8L346.9 219.7zM315.5 275.5v106.5H155.6V275.5h-20.8v126.9h201.5V275.5H315.5z"/></svg><!--[if lt IE 9]><em>StackOverflow</em><![endif]--></a></li>
   {% endif %}
 
   {% if site.footer-links.tumblr %}


### PR DESCRIPTION
## Summary
- update outdated http references in includes

## Testing
- `bundle install --quiet` *(fails: 403 Forbidden)*
- `jekyll --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6879dafa8a9083248e1416f0aed44d11